### PR TITLE
Do not extend App to avoid NPE in Example

### DIFF
--- a/src/main/scala/Example.scala
+++ b/src/main/scala/Example.scala
@@ -7,7 +7,10 @@ import doodle.backend.StandardInterpreter._
 // To use this example, open the SBT console and type:
 //
 // Example.image.draw
-object Example extends App {
+object Example {
   val image = circle(10).fillColor(Color.red) on circle(20) on circle(30)
-  image.draw
+
+  def main(args: Array[String]): Unit = {
+    image.draw
+  }
 }


### PR DESCRIPTION
`Example extends App` was causing a `NullPointerException` when running
`Example.image.draw` from the console. Solves https://github.com/underscoreio/creative-scala/issues/37