### PR TITLE
Update/sbt and scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.4"
 
 resolvers += Resolver.bintrayRepo("underscoreio", "training")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=1.1.0


### PR DESCRIPTION
sbt 0.13.11 was causing a `scala.reflect.internal.MissingRequirementError: object java.lang.Object in compiler mirror not found` when using Java9. v1.1.0 is also already supported by Intellij

scala 2.12.4 improved Java9 compatibility