### PR TITLE
bump sbt version to 1.1.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.6


### PR DESCRIPTION
recent 1.1.x versions have some pretty significant bug fixes in areas such as:

* is `~` slow/unreliable on some OSs
* can you run `console` more than once without messing up your terminal

to name a couple