### PR TITLE
bump Scala version 2.12.4 -> 2.12.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 
 resolvers += Resolver.bintrayRepo("underscoreio", "training")
 


### PR DESCRIPTION
2.12.6 has been out long enough now that I think this is a
safe, conservative change