### PR TITLE
don't use obsolete JVM flags

### DIFF
--- a/sbt.bat
+++ b/sbt.bat
@@ -1,1 +1,1 @@
-java -Xmx3g -Xms1g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:MaxPermSize=512m -XX:+UseNUMA -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled -jar sbt-launch.jar %*
+java -Xmx3g -Xms1g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:+UseNUMA -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled -jar sbt-launch.jar %*

--- a/sbt.sh
+++ b/sbt.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-java -Xmx3g -Xms1g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:MaxPermSize=512m -XX:+UseNUMA -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled -jar sbt-launch.jar "$@"
+java -Xmx3g -Xms1g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:+UseNUMA -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled -jar sbt-launch.jar "$@"


### PR DESCRIPTION
this prevents the following warning from being printed:

    Java HotSpot(TM) 64-Bit Server VM warning:
    ignoring option MaxPermSize=512m; support was removed in 8.0

note that we're on Scala 2.12, which means we know we're on Java 8+
anyway