### PR TITLE
Enable fork

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,3 +19,6 @@ libraryDependencies ++= Seq(
   "underscoreio" %% "doodle" % "0.8.3",
   "org.typelevel" %% "cats-core" % "1.1.0"
 )
+
+Compile / fork := true
+Test / fork := true


### PR DESCRIPTION
On macOS, this allows the example to quit after `run` without taking down sbt process with:

```
Could not exit(0): no application associated with Thread[AppKit Thread,5,system]
2019-04-25 09:07:42.021 java[48062:11015174] JavaNativeFoundation error occurred obtaining Java exception description
2019-04-25 09:07:42.021 java[48062:11015174] JavaNativeFoundation error occurred obtaining Java exception description
2019-04-25 09:07:42.021 java[48062:11015174] Internal JNF Error: failed calling Throwable.toString()
```