### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 This is a template project designed for people taking [Creative Scala][creative-scala].
 
-Fork or clone this template. (What's the difference? If you fork this repository you get your own copy on Github. You can then clone that repository to get a copy on your computer and save work back to your fork on Github and share it with other programmers. If you clone this repository without forking you get a copy on your computer but no copy on Github that you can save work back to and share.)
+1. Fork or clone this template. 
+    - What's the difference? 
+        - If you fork this repository, you get your own copy on Github. You can then clone that repository to get a copy on your computer and save work back to your fork on Github and share it with other programmers. 
+        - If you clone this repository without forking, you get a copy on your computer but no copy on Github that you can save work back to and share.
 
 Then run `sbt.sh` (OS X and Linux) or `sbt.bat` (Windows) to start SBT.
 
-Finally type `console` in SBT and then type `Example.image.draw`. If you see a picture of three nested circles everything is working well.
+Finally, type `console` in SBT and then type `Example.image.draw()`. If a popup window with a picture of three nested circles loads, everything is working well.
 
 You can edit the file `Example.scala` to create your own code. See [Creative Scala][creative-scala] for more!
 


### PR DESCRIPTION
Needs `()`. Otherwise, I get this in the console:

```
scala> Example.image.draw
<console>:27: error: could not find implicit value for parameter renderer: doodle.effect.DefaultRenderer[[x[_]]doodle.language.Basic[x],Nothing,Nothing,Nothing]
       Example.image.draw
```

Plus a few minor comma and reformatting changes.